### PR TITLE
Fix dependabot ignore settings for ecj

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,7 +11,7 @@ updates:
     - dependency-name: org.apache.poi:poi-ooxml-schemas
     - dependency-name: org.eclipse.jdt:ecj
       versions:
-      - "[3.34.0,+]"
+      - ">=3.34.0"
 
 - package-ecosystem: "github-actions"
   directory: "/"


### PR DESCRIPTION
The ECJ 3.34.0+ PR (#299) wasn't tested and of course it didn't work:

> The property '#/updates/0/ignore/3/versions' includes invalid version requirements for a gradle ignore condition

This is tested now, and also allows to lift the version. Got a hint from a SO question: [How can I change my dependabot config to exclude major versions](1).

[1]: https://stackoverflow.com/a/64042332

Fixes: f074b28e2af2 ("Prevent ecj (used by fastergt plugin) updates for 3.34.0 and higher")