### PR TITLE
gradle: explicitly require specific version of Java toolchain

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,8 +28,9 @@ subprojects {
     options.debug = true
     options.debugOptions.debugLevel = "source,lines,vars"
   }
-  sourceCompatibility = 11
-  targetCompatibility = 11
+  java.toolchain {
+    languageVersion = JavaLanguageVersion.of(11)
+  }
 
   repositories {
     mavenCentral()

--- a/replay-tests/helloworld-kotlin/build.gradle
+++ b/replay-tests/helloworld-kotlin/build.gradle
@@ -10,15 +10,5 @@ dependencies {
 repositories {
   mavenCentral()
 }
-compileKotlin {
-  kotlinOptions {
-    jvmTarget = "11"
-  }
-}
-compileTestKotlin {
-  kotlinOptions {
-    jvmTarget = "11"
-  }
-}
 
 apply from: '../replay-tests.gradle'


### PR DESCRIPTION
to avoid build time errors:

```
> Task :framework:compileJava FAILED

FAILURE: Build failed with an exception.

* What went wrong: Execution failed for task ':framework:compileJava'.
> invalid source release: 11
```

Since Gradle 8.0.2 one needs to opt in for automatic toolchain provisioning with adding plugins to "settings.gradle".

See [Gradle: Toolchains for JVM projects](https://docs.gradle.org/8.5/userguide/toolchains.html) for details!

The best way to target a Java version is to build with that specific version of Java.
If that's not possible, one could use the "release" option, available from Java 10 within Gradle.

See [Gradle: Targeting a specific Java version](https://docs.gradle.org/8.5/userguide/building_java_projects.html#sec:java_cross_compilation) for details.

While at it, let Gradle configure the Kotlin test app automatically.

See [Kotlin: Gradle Java toolchains support﻿](https://kotlinlang.org/docs/gradle-configure-project.html#gradle-java-toolchains-support) for details.
