### PR TITLE
Java 17

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           distribution: 'temurin'
           cache: 'gradle'
-          java-version: '11'
+          java-version: '17'
       - name: Run unit-tests
         uses: gradle/gradle-build-action@v3
         with:

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ These were not used at Codeborne, but could be reintroduced if needed.
 
 #### Requirements
 
-At least JDK 11, and at most JDK 17 (as we are stuck at Hibernate 5.6 which does not support JDK versions beyond 17).
+JDK 17 (as we are stuck at Hibernate 5.6 which does not support JDK versions beyond 17).
 
 
 ## Getting started
@@ -104,7 +104,7 @@ with the value: `-parameters` (also found in the `build.gradle` file, it put the
 4. Go to `Run -> Edit Configurations...`, click the `+` (Add New Configuration) in the top-right corner and select "Application"
 5. Fill in the following details, and click `OK`:
   * *Name*: `Criminals` (how this run/debug configuration shows up in the IntelliJ UI)
-  * *JDK/JRE*: select one you prefer (Java 11 is a minimum requirement, Java 17 seems to work fine)
+  * *JDK/JRE*: select one you prefer (Java 17 seems to work fine)
   * *Use classpath of module*: `criminals.main`
   * *Main class*: `replay.replay-tests.criminals.Application` (the package name, `criminals` should match the package that contains you `Application` class in `app/`)
   * *VM options* (shown with *Modify options* drop-down item *Add VM options*): `-XX:+ShowCodeDetailsInExceptionMessages` (for more helpful errors) (applicable only for Java 14+)

--- a/build.gradle
+++ b/build.gradle
@@ -29,7 +29,7 @@ subprojects {
     options.debugOptions.debugLevel = "source,lines,vars"
   }
   java.toolchain {
-    languageVersion = JavaLanguageVersion.of(11)
+    languageVersion = JavaLanguageVersion.of(17)
   }
 
   repositories {

--- a/fastergt/build.gradle
+++ b/fastergt/build.gradle
@@ -1,9 +1,6 @@
 dependencies {
   implementation project(':framework')
-  implementation('org.eclipse.jdt:ecj:3.33.0') {
-    transitive = false
-    because "ECJ 3.34.0 dropped Java 11 compatibility, see https://github.com/eclipse-jdt/eclipse.jdt.core/commit/c25e22b15eebcc780b1a6c54d7af1911841c49b8"
-  }
+  implementation('org.eclipse.jdt:ecj:3.37.0')
   implementation("org.apache.commons:commons-lang3:$commonsLangVersion")
   implementation "org.apache.commons:commons-text:$commonsTextVersion"
   testImplementation project(':framework').sourceSets.test.compileClasspath

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.6-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/gradlew.bat
+++ b/gradlew.bat
@@ -43,11 +43,11 @@ set JAVA_EXE=java.exe
 %JAVA_EXE% -version >NUL 2>&1
 if %ERRORLEVEL% equ 0 goto execute
 
-echo.
-echo ERROR: JAVA_HOME is not set and no 'java' command could be found in your PATH.
-echo.
-echo Please set the JAVA_HOME variable in your environment to match the
-echo location of your Java installation.
+echo. 1>&2
+echo ERROR: JAVA_HOME is not set and no 'java' command could be found in your PATH. 1>&2
+echo. 1>&2
+echo Please set the JAVA_HOME variable in your environment to match the 1>&2
+echo location of your Java installation. 1>&2
 
 goto fail
 
@@ -57,11 +57,11 @@ set JAVA_EXE=%JAVA_HOME%/bin/java.exe
 
 if exist "%JAVA_EXE%" goto execute
 
-echo.
-echo ERROR: JAVA_HOME is set to an invalid directory: %JAVA_HOME%
-echo.
-echo Please set the JAVA_HOME variable in your environment to match the
-echo location of your Java installation.
+echo. 1>&2
+echo ERROR: JAVA_HOME is set to an invalid directory: %JAVA_HOME% 1>&2
+echo. 1>&2
+echo Please set the JAVA_HOME variable in your environment to match the 1>&2
+echo location of your Java installation. 1>&2
 
 goto fail
 


### PR DESCRIPTION
Now Replay will require at least Java 17.
Before this change, Replay worked on Java 11.