### PR TITLE
#395 listen incoming requests on address "0.0.0.0" instead of "localhost"

### DIFF
--- a/javanet/src/play/server/javanet/Server.java
+++ b/javanet/src/play/server/javanet/Server.java
@@ -75,7 +75,7 @@ public class Server {
       return System.getProperty("http.address");
     }
 
-    return "localhost";
+    return "0.0.0.0";
   }
 
   public int port() {


### PR DESCRIPTION
We already listened "0.0.0.0" in "netty3" and "netty4" implementations, but not in "javanet".