### PR TITLE
Increade max mem and default to utf8

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 org.gradle.daemon=false
 org.gradle.configureondemand=true
 org.gradle.parallel=true
-org.gradle.jvmargs=-Xmx256m -Dfile.encoding=US-ASCII
+org.gradle.jvmargs=-Xmx512m -Dfile.encoding=UTF-8


### PR DESCRIPTION
I got OOMs running the tests, so I doubled the `-Xmx` value.

Also I found some US-ASCII charset setting, so I changed it to UTF-8 and all the tests were still passing.