### PR TITLE
Extract dependency specs to TOML catalog

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,19 +1,5 @@
 defaultTasks 'clean', 'check', 'publishToMavenLocal'
 
-ext {
-  commonsLangVersion = '3.17.0'
-  netty4Version = '4.1.113.Final'
-  commonsTextVersion = '1.12.0'
-  slf4jVersion = '2.0.16'
-  assertjVersion = '3.26.3'
-  mockitoVersion = '5.13.0'
-  pdfTestVersion = '1.9.0'
-  groovyVersion = '3.0.22'
-  httpclientVersion = '4.5.14'
-  restAssuredVersion = '5.5.0'
-  junitVersion = '5.11.0'
-}
-
 subprojects {
 
   group='io.github.replay-framework'
@@ -82,10 +68,10 @@ subprojects {
   }
 
   dependencies {
-    testImplementation("org.junit.jupiter:junit-jupiter-api:$junitVersion")
-    testImplementation("org.junit.jupiter:junit-jupiter-params:$junitVersion")
-    testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:$junitVersion")
-    testImplementation("org.mockito:mockito-core:$mockitoVersion")
-    testImplementation("org.assertj:assertj-core:$assertjVersion")
+    testImplementation(libs.junitApi)
+    testImplementation(libs.junitParams)
+    testRuntimeOnly(libs.junitEngine)
+    testImplementation(libs.mockitoCore)
+    testImplementation(libs.assertjCore)
   }
 }

--- a/excel/build.gradle
+++ b/excel/build.gradle
@@ -1,20 +1,16 @@
-ext {
-  poiVersion = '3.17'
-}
-
 dependencies {
   implementation project(':framework')
   testImplementation project(':framework').sourceSets.test.compileClasspath
   
-  api('net.sf.jxls:jxls-core:1.0.6') {transitive = false}
-  api('net.sf.jxls:jxls-reader:1.0.6') {transitive = false}
-  implementation('org.apache.commons:commons-jexl:2.1.1') {transitive = false}
-  api("org.apache.poi:poi:$poiVersion") {transitive = false}
-  api("org.apache.poi:poi-ooxml:$poiVersion") {transitive = false}
-  api("org.apache.poi:poi-ooxml-schemas:$poiVersion") {transitive = false}
-  api('org.apache.xmlbeans:xmlbeans:5.2.1') {transitive = false}
-  implementation('commons-digester:commons-digester:2.1') {transitive = false}
-  implementation('org.apache.commons:commons-collections4:4.4') {transitive = false}
+  api(libs.jxlsCore) {transitive = false}
+  api(libs.jxlsReader) {transitive = false}
+  implementation(libs.commonsJexl) {transitive = false}
+  api(libs.poi) {transitive = false}
+  api(libs.poiOoxml) {transitive = false}
+  api(libs.poiOoxmlSchemas) {transitive = false}
+  api(libs.xmlBeans) {transitive = false}
+  implementation(libs.commonsDigester) {transitive = false}
+  implementation(libs.commonsCollections4) {transitive = false}
 }
 
 apply from: rootProject.file('gradle/deploy.gradle')

--- a/fastergt/build.gradle
+++ b/fastergt/build.gradle
@@ -3,13 +3,13 @@ dependencies {
   implementation('org.eclipse.jdt:ecj:3.37.0')
 
   // Groovy 4 can be found in org.apache.groovy
-  api("org.codehaus.groovy:groovy:$groovyVersion")
-  api("org.codehaus.groovy:groovy-xml:$groovyVersion")
+  api(libs.groovy)
+  api(libs.groovyXml)
 
-  implementation("org.apache.commons:commons-lang3:$commonsLangVersion")
-  implementation "org.apache.commons:commons-text:$commonsTextVersion"
+  implementation(libs.commonsLang3)
+  implementation(libs.commonsText)
   testImplementation project(':framework').sourceSets.test.compileClasspath
-  testImplementation("org.assertj:assertj-core:$assertjVersion")
+  testImplementation(libs.assertjCore)
 }
 
 apply from: rootProject.file('gradle/deploy.gradle')

--- a/fastergt/build.gradle
+++ b/fastergt/build.gradle
@@ -1,6 +1,6 @@
 dependencies {
   implementation project(':framework')
-  implementation('org.eclipse.jdt:ecj:3.37.0')
+  implementation(libs.ecj)
 
   // Groovy 4 can be found in org.apache.groovy
   api(libs.groovy)

--- a/framework/build.gradle
+++ b/framework/build.gradle
@@ -1,36 +1,35 @@
 dependencies {
-  api('com.google.code.findbugs:jsr305:3.0.2')
-  implementation('io.github.classgraph:classgraph:4.8.176')
-  api('com.zaxxer:HikariCP:5.1.0')
-  api('com.google.code.gson:gson:2.11.0')
-  // Cannot upgrade to org.asynchttpclient:async-http-client as that requires Netty4 and we use Netty3
-  implementation('com.ning:async-http-client:1.9.40') {
+  api(libs.findbugsJsr305)
+  implementation(libs.classGraph)
+  api(libs.hikariCp)
+  api(libs.gson)
+  implementation(libs.asyncHttpClient) {
     exclude group: 'io.netty'
   }
-  api('com.google.guava:guava:33.3.0-jre') {transitive = false}
-  api('commons-beanutils:commons-beanutils:1.9.4') {transitive = false}
-  api('commons-codec:commons-codec:1.17.1') {transitive = false}
-  api('org.apache.commons:commons-email:1.6.0') {transitive = false}
-  api('commons-fileupload:commons-fileupload:1.5.0.redhat-00001')
-  api('commons-io:commons-io:2.17.0')
-  implementation("org.apache.commons:commons-lang3:$commonsLangVersion")
-  implementation "org.apache.commons:commons-text:$commonsTextVersion"
-  implementation 'com.github.f4b6a3:ulid-creator:5.2.3'
-  api('commons-logging:commons-logging:1.3.4')
-  api('javax.mail:mail:1.4.7')
-  api('jakarta.inject:jakarta.inject-api:2.0.1')
-  implementation('ch.qos.reload4j:reload4j:1.2.25')
-  implementation('org.ehcache:ehcache:3.10.8')
-  api('net.sf.oval:oval:3.2.1')
-  api('org.hibernate:hibernate-core:6.6.1.Final')
+  api(libs.guava) {transitive = false}
+  api(libs.commonsBeanutils) {transitive = false}
+  api(libs.commonsCodec) {transitive = false}
+  api(libs.commonsEmail) {transitive = false}
+  api(libs.commonsFileUpload)
+  api(libs.commonsIo)
+  implementation(libs.commonsLang3)
+  implementation(libs.commonsText)
+  implementation(libs.ulidCreator)
+  api(libs.commonsLogging)
+  api(libs.javaxMail)
+  api(libs.jakartaInject)
+  implementation(libs.reload4j)
+  implementation(libs.ehcache)
+  api(libs.oval)
+  api(libs.hibernateCore)
   // Hibernate 6.2-6.5 are only compatible with Jakarta Persistence 3.1
-  api('jakarta.persistence:jakarta.persistence-api:3.1.0')
-  api('org.hibernate.common:hibernate-commons-annotations:7.0.1.Final')
-  implementation('org.hibernate:hibernate-jcache:6.6.1.Final') {transitive = false}
-  api("org.slf4j:slf4j-api:$slf4jVersion")
-  api("org.slf4j:slf4j-reload4j:$slf4jVersion")
-  api("org.slf4j:jul-to-slf4j:$slf4jVersion")
-  api('net.spy:spymemcached:2.12.3')
+  api(libs.jakartaPersistence)
+  api(libs.hibernateCommonsAnnotations)
+  implementation(libs.hibernateJCache) {transitive = false}
+  api(libs.slf4j)
+  api(libs.slf4jReload4j)
+  api(libs.julToSlf4j)
+  api(libs.spymemcached)
 }
 
 task generateReplayVersion(type: Exec) {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -112,6 +112,7 @@ groovyXml = { group = "org.codehaus.groovy", name = "groovy-xml", version.ref = 
 
 # :replay-tests
 pdfTest = { group = "com.codeborne", name = "pdf-test", version = "1.9.0" }
+selenide = { group = "com.codeborne", name = "selenide", version = "7.4.1" }
 
 # :replay-tests:criminals
 httpClient = { group = "org.apache.httpcomponents", name = "httpclient", version.ref = "httpclientVersion" }
@@ -132,7 +133,7 @@ h2 = { group = "com.h2database", name = "h2", version = "2.3.232" }
 liquibaseCore = { group = "org.liquibase", name ="liquibase-core", version = "4.29.2" }
 
 
-# [bundles] # Only useful for sharing sets of dependencies sbetween (sub)projects
+# [bundles] # Only useful for sharing sets of dependencies between (sub)projects
 
 
 [plugins]

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,140 @@
+# This is our "version catalog", as Gradle calls it.
+#
+# It specifies all the versions and dependencies, in a way that IntelliJ (and tools like Dependabot) can understand it.
+# It is important to know that (as it says on the Gradle website):
+# > A dependency catalog doesn’t enforce the version of a dependency: like a regular dependency notation,
+# > it declares the requested version or a rich version. That version is not necessarily the version that
+# > is selected during conflict resolution.
+# In other words: if you really want to pin versions down (which is a good idea), you need to use `strictly` for
+# individual dependencies, or version locking for the project as a whole:
+# https://docs.gradle.org/current/userguide/dependency_locking.html
+
+
+[versions]
+
+# [PINNED] = Pinned, do not upgrade this dependency (a comment should be added to explain why).
+
+assertjVersion = "3.26.3"
+commonsLangVersion = "3.17.0"
+commonsTextVersion = "1.12.0"
+flyingSaucerPdfVersion = "9.9.4"
+groovyVersion = "3.0.22"
+hibernateVersion = "6.6.1.Final"
+httpclientVersion = "4.5.14"
+junitVersion = "5.11.0"
+jxlsVersion = "1.0.6"
+kotlinVersion = "2.0.20"
+mockitoVersion = "5.13.0"
+netty4Version = "4.1.113.Final"
+poiVersion = "3.17"
+restAssuredVersion = "5.5.0"
+slf4jVersion = "2.0.16"
+yahpVersion = "1.3"
+
+
+[libraries]
+
+# rootProject
+junitApi = { group = "org.junit.jupiter", name = "junit-jupiter-api", version.ref = "junitVersion" }
+junitParams = { group = "org.junit.jupiter", name = "junit-jupiter-params", version.ref = "junitVersion" }
+junitEngine = { group = "org.junit.jupiter", name = "junit-jupiter-engine", version.ref = "junitVersion" }
+mockitoCore = { group = "org.mockito", name = "mockito-core", version.ref = "mockitoVersion" }
+assertjCore = { group = "org.assertj", name = "assertj-core", version.ref = "assertjVersion" }
+
+# :framework
+findbugsJsr305 = { group = "com.google.code.findbugs", name = "jsr305", version = "3.0.2" }
+classGraph = { group = "io.github.classgraph", name = "classgraph", version = "4.8.176" }
+hikariCp = { group = "com.zaxxer", name = "HikariCP", version = "5.1.0" }
+gson = { group = "com.google.code.gson", name = "gson", version = "2.11.0" }
+# Cannot upgrade to org.asynchttpclient:async-http-client as that requires Netty4 and we use Netty3
+asyncHttpClient = { group = "com.ning", name = "async-http-client", version = "1.9.40" }
+guava = { group = "com.google.guava", name = "guava", version = "33.3.0-jre" }
+commonsBeanutils = { group = "commons-beanutils", name = "commons-beanutils", version = "1.9.4" }
+commonsCodec = { group = "commons-codec", name = "commons-codec", version = "1.17.1" }
+commonsEmail = { group = "org.apache.commons", name = "commons-email", version = "1.6.0" }
+commonsFileUpload = { group = "commons-fileupload", name = "commons-fileupload", version = "1.5.0.redhat-00001" }
+commonsIo = { group = "commons-io", name = "commons-io", version = "2.17.0" }
+commonsLang3 = { group = "org.apache.commons", name = "commons-lang3", version.ref = "commonsLangVersion" }
+commonsText = { group = "org.apache.commons", name = "commons-text", version.ref = "commonsTextVersion" }
+commonsLogging = { group = "commons-logging", name = "commons-logging", version = "1.3.4" }
+ulidCreator = { group = "com.github.f4b6a3", name = "ulid-creator", version = "5.2.3" }
+javaxMail = { group = "javax.mail", name = "mail", version = "1.4.7" }
+jakartaInject = { group = "jakarta.inject", name = "jakarta.inject-api", version = "2.0.1" }
+reload4j = { group = "ch.qos.reload4j", name = "reload4j", version = "1.2.25" }
+ehcache = { group = "org.ehcache", name = "ehcache", version = "3.10.8" }
+oval = { group = "net.sf.oval", name = "oval", version = "3.2.1" }
+hibernateCore = { group = "org.hibernate", name = "hibernate-core", version.ref = "hibernateVersion" }
+hibernateJCache = { group = "org.hibernate", name = "hibernate-jcache", version.ref = "hibernateVersion" }
+# Hibernate up until 6.6 is only compatible with Jakarta Persistence 3.1
+jakartaPersistence = { group = "jakarta.persistence", name = "jakarta.persistence-api", version = "3.1.0" }
+hibernateCommonsAnnotations = { group = "org.hibernate.common", name = "hibernate-commons-annotations", version = "7.0.1.Final" }
+slf4j = { group = "org.slf4j", name = "slf4j-api", version.ref = "slf4jVersion" }
+slf4jReload4j = { group = "org.slf4j", name = "slf4j-reload4j", version.ref = "slf4jVersion" }
+julToSlf4j = { group = "org.slf4j", name = "jul-to-slf4j", version.ref = "slf4jVersion" }
+spymemcached = { group = "net.spy", name = "spymemcached", version = "2.12.3" }
+
+# :netty3
+netty3 = { group = "io.netty", name = "netty", version = "3.10.6.Final" }
+
+# :netty4
+netty4 = { group = "io.netty", name = "netty-all", version.ref = "netty4Version" }
+
+# :javanet
+netty4Codec = { group = "io.netty", name = "netty-codec", version.ref = "netty4Version" }
+netty4CodecHttp = { group = "io.netty", name = "netty-codec-http", version.ref = "netty4Version" }
+netty4Common = { group = "io.netty", name = "netty-common", version.ref = "netty4Version" }
+
+# :guice
+guice = { group = "com.google.inject", name = "guice", version = "6.0.0" }
+
+# :excel
+jxlsCore = { group = "net.sf.jxls", name = "jxls-core", version.ref = "jxlsVersion" }
+jxlsReader = { group = "net.sf.jxls", name = "jxls-reader", version.ref = "jxlsVersion" }
+commonsJexl = { group = "org.apache.commons", name = "commons-jexl", version = "2.1.1" }
+poi = { group = "org.apache.poi", name = "poi", version.ref = "poiVersion" }
+poiOoxml = { group = "org.apache.poi", name = "poi-ooxml", version.ref = "poiVersion" }
+poiOoxmlSchemas = { group = "org.apache.poi", name = "poi-ooxml-schemas", version.ref = "poiVersion" }
+xmlBeans = { group = "org.apache.xmlbeans", name = "xmlbeans", version = "5.2.1" }
+commonsDigester = { group = "commons-digester", name = "commons-digester", version = "2.1" }
+commonsCollections4 = { group = "org.apache.commons", name = "commons-collections4", version = "4.4" }
+
+# :pdf
+flyingSaucerPdf = { group = "org.xhtmlrenderer", name = "flying-saucer-pdf", version.ref = "flyingSaucerPdfVersion" }
+shaniParser = { group = "com.google.code.maven-play-plugin.org.allcolor.shanidom", name = "shani-parser", version = "1.4.17-patched-yahp-1.3" }
+yahp = { group = "com.google.code.maven-play-plugin.org.allcolor.yahp", name = "yahp", version.ref = "yahpVersion" }
+yahpInternal = { group = "com.google.code.maven-play-plugin.org.allcolor.yahp", name = "yahp-internal", version.ref = "yahpVersion" }
+
+# :fastergt
+ecj = { group = "org.eclipse.jdt", name = "ecj", version = "3.37.0" }
+groovy = { group = "org.codehaus.groovy", name = "groovy", version.ref = "groovyVersion" }
+groovyXml = { group = "org.codehaus.groovy", name = "groovy-xml", version.ref = "groovyVersion" }
+
+
+# :replay-tests
+pdfTest = { group = "com.codeborne", name = "pdf-test", version = "1.9.0" }
+
+# :replay-tests:criminals
+httpClient = { group = "org.apache.httpcomponents", name = "httpclient", version.ref = "httpclientVersion" }
+fluentHc = { group = "org.apache.httpcomponents", name = "fluent-hc", version.ref = "httpclientVersion" }
+subethasmtp = { group = "org.subethamail", name = "subethasmtp", version = "3.1.7" }
+wiremock = { group = "com.github.tomakehurst", name = "wiremock", version = "3.0.1" }
+
+# :replay-tests:helloworld
+restAssured = { group = "io.rest-assured", name = "rest-assured", version.ref = "restAssuredVersion" }
+jsonSchemaValidator = { group = "io.rest-assured", name = "json-schema-validator", version.ref = "restAssuredVersion" }
+jacksonDatabind = { group = "com.fasterxml.jackson.core", name = "jackson-databind", version = "2.17.2" }
+
+# :replay-tests:helloworld-kotlin
+kotlinStdlib = { group = "org.jetbrains.kotlin", name = "kotlin-stdlib-jdk8" }
+
+# :replay-tests:liquibase
+h2 = { group = "com.h2database", name = "h2", version = "2.3.232" }
+liquibaseCore = { group = "org.liquibase", name ="liquibase-core", version = "4.29.2" }
+
+
+# [bundles] # Only useful for sharing sets of dependencies sbetween (sub)projects
+
+
+[plugins]
+
+kotlinJvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlinVersion" }

--- a/javanet/build.gradle
+++ b/javanet/build.gradle
@@ -1,12 +1,12 @@
 dependencies {
   implementation project(':framework')
   testImplementation project(':framework').sourceSets.test.compileClasspath
-  implementation "org.apache.commons:commons-text:$commonsTextVersion"
+  implementation(libs.commonsText)
   
   // We use only few small jars from Netty project to parse http cookies
-  implementation("io.netty:netty-codec:$netty4Version") {transitive = false}
-  implementation("io.netty:netty-codec-http:$netty4Version") {transitive = false}
-  implementation("io.netty:netty-common:$netty4Version") {transitive = false}
+  implementation(libs.netty4Codec) {transitive = false}
+  implementation(libs.netty4CodecHttp) {transitive = false}
+  implementation(libs.netty4Common) {transitive = false}
 }
 
 apply from: rootProject.file('gradle/deploy.gradle')

--- a/liquibase/build.gradle
+++ b/liquibase/build.gradle
@@ -2,7 +2,7 @@ dependencies {
   implementation project(':framework')
   testImplementation project(':framework').sourceSets.test.compileClasspath
 
-  implementation('org.liquibase:liquibase-core:4.29.2') {transitive = false}
+  implementation(libs.liquibaseCore) {transitive = false}
 }
 
 apply from: rootProject.file('gradle/deploy.gradle')

--- a/netty3/build.gradle
+++ b/netty3/build.gradle
@@ -1,8 +1,8 @@
 dependencies {
-  implementation 'io.netty:netty:3.10.6.Final'
+  implementation(libs.netty3)
   implementation project(':framework')
   testImplementation project(':framework').sourceSets.test.compileClasspath
-  implementation("org.apache.commons:commons-lang3:$commonsLangVersion")
+  implementation(libs.commonsLang3)
 }
 
 apply from: rootProject.file('gradle/deploy.gradle')

--- a/netty4/build.gradle
+++ b/netty4/build.gradle
@@ -1,9 +1,9 @@
 dependencies {
-  implementation "io.netty:netty-all:$netty4Version"
+  implementation(libs.netty4)
 
   implementation project(':framework')
   testImplementation project(':framework').sourceSets.test.compileClasspath
-  implementation("org.apache.commons:commons-lang3:$commonsLangVersion")
+  implementation(libs.commonsLang3)
 }
 
 apply from: rootProject.file('gradle/deploy.gradle')

--- a/pdf/build.gradle
+++ b/pdf/build.gradle
@@ -3,11 +3,6 @@ configurations {
   implementation.extendsFrom thirdParty
 }
 
-ext {
-  FLYING_SOURCER_VERSION = '9.9.4'
-  YAHP_VERSION = 1.3
-}
-
 test {
   include 'play/**/*'
   include 'org/**/*'
@@ -16,14 +11,14 @@ test {
 dependencies {
   implementation project(':framework')
   testImplementation project(':framework').sourceSets.test.compileClasspath
-  testImplementation("org.mockito:mockito-core:$mockitoVersion")
+  testImplementation(libs.mockitoCore)
 
-  implementation("org.apache.commons:commons-lang3:$commonsLangVersion")
-  implementation("org.xhtmlrenderer:flying-saucer-pdf:$FLYING_SOURCER_VERSION")
+  implementation(libs.commonsLang3)
+  implementation(libs.flyingSaucerPdf)
 
-  implementation('com.google.code.maven-play-plugin.org.allcolor.shanidom:shani-parser:1.4.17-patched-yahp-1.3')
-  api("com.google.code.maven-play-plugin.org.allcolor.yahp:yahp:$YAHP_VERSION") {transitive = false}
-  thirdParty("com.google.code.maven-play-plugin.org.allcolor.yahp:yahp-internal:$YAHP_VERSION") {transitive = false}
+  implementation(libs.shaniParser)
+  api(libs.yahp) {transitive = false}
+  thirdParty(libs.yahpInternal) {transitive = false}
 }
 
 task extractThirdPartyJars(type: Sync) {

--- a/replay-tests/criminals/build.gradle
+++ b/replay-tests/criminals/build.gradle
@@ -2,12 +2,12 @@ dependencies {
   implementation project(':fastergt')
   implementation project(':guice')
   implementation project(':pdf')
-  implementation("org.apache.httpcomponents:httpclient:$httpclientVersion")
-  implementation("org.apache.httpcomponents:fluent-hc:$httpclientVersion")
+  implementation(libs.httpClient)
+  implementation(libs.fluentHc)
 
-  testImplementation "com.codeborne:pdf-test:$pdfTestVersion"
-  testImplementation('org.subethamail:subethasmtp:3.1.7') {transitive = false}
-  testImplementation('com.github.tomakehurst:wiremock:3.0.1') {
+  testImplementation(libs.pdfTest)
+  testImplementation(libs.subethasmtp) {transitive = false}
+  testImplementation(libs.wiremock) {
     exclude group: 'org.eclipse.jetty', module: 'jetty-client'
   }
 }

--- a/replay-tests/helloworld-kotlin/build.gradle
+++ b/replay-tests/helloworld-kotlin/build.gradle
@@ -1,14 +1,11 @@
 plugins {
-  id 'org.jetbrains.kotlin.jvm' version '2.0.20'
+  alias(libs.plugins.kotlinJvm)
 }
 dependencies {
-  implementation('com.google.guava:guava:33.3.0-jre') {transitive = false}
-  implementation "org.jetbrains.kotlin:kotlin-stdlib"
+  implementation(libs.guava) {transitive = false}
+  implementation(libs.kotlinStdlib)
   implementation project(':pdf')
-  testImplementation "com.codeborne:pdf-test:$pdfTestVersion"
-}
-repositories {
-  mavenCentral()
+  testImplementation(libs.pdfTest)
 }
 
 apply from: '../replay-tests.gradle'

--- a/replay-tests/helloworld/build.gradle
+++ b/replay-tests/helloworld/build.gradle
@@ -1,13 +1,13 @@
 dependencies {
-  implementation('com.google.guava:guava:33.3.0-jre') {transitive = false}
+  implementation(libs.guava) {transitive = false}
   implementation project(':pdf')
-  testImplementation("org.assertj:assertj-core:$assertjVersion")
-  testImplementation "com.codeborne:pdf-test:$pdfTestVersion"
-  testImplementation("io.rest-assured:rest-assured:$restAssuredVersion") {
+  testImplementation(libs.assertjCore)
+  testImplementation(libs.pdfTest)
+  testImplementation(libs.restAssured) {
     exclude group: 'org.apache.groovy'
   }
-  testImplementation "io.rest-assured:json-schema-validator:$restAssuredVersion"
-  testImplementation("com.fasterxml.jackson.core:jackson-databind:2.17.2") {
+  testImplementation(libs.jsonSchemaValidator)
+  testImplementation(libs.jacksonDatabind) {
     because 'used by rest-assured'
   }
 }

--- a/replay-tests/liquibase-app/build.gradle
+++ b/replay-tests/liquibase-app/build.gradle
@@ -1,9 +1,9 @@
 dependencies {
   implementation project(':liquibase')
-  implementation('com.h2database:h2:2.3.232')
+  implementation(libs.h2)
   implementation project(':guice')
   implementation project(':excel')
-  testImplementation("org.assertj:assertj-core:$assertjVersion")
+  testImplementation(libs.assertjCore)
 }
 
 apply from: '../replay-tests.gradle'

--- a/replay-tests/multi-module-app/app/build.gradle
+++ b/replay-tests/multi-module-app/app/build.gradle
@@ -1,6 +1,6 @@
 dependencies {
   implementation project(':replay-tests:multi-module-app:core')
-  testImplementation("org.assertj:assertj-core:$assertjVersion")
+  testImplementation(libs.assertjCore)
 }
 
 apply from: '../../replay-tests.gradle'

--- a/replay-tests/replay-tests.gradle
+++ b/replay-tests/replay-tests.gradle
@@ -32,7 +32,7 @@ dependencies {
   javanetTestClasspath project(':javanet')
 
   // Test dependencies:
-  testImplementation('com.codeborne:selenide:7.4.1') {
+  testImplementation(libs.selenide) {
     exclude group: 'io.netty'
     exclude group: 'io.opentelemetry'
     exclude group: 'org.asynchttpclient'


### PR DESCRIPTION
It works really well for us. All the dep specs in one place. Is understood by Dependabot and IntelliJ (unlike the $xyzVersion interpolation we were using). Ties in really nice with the KTS syntax/tooling (autocompletion, etc.)