### PR TITLE
add test showing how to use `@{...}` and `@{'...'}` in html templates

### DIFF
--- a/framework/src/play/templates/TemplateLoader.java
+++ b/framework/src/play/templates/TemplateLoader.java
@@ -91,6 +91,10 @@ public class TemplateLoader {
   }
 
   private static Template getTemplateFromClasspath(String path, URL resource) {
+    if ("file".equals(resource.getProtocol())) {
+      return TemplateLoader.load(new File(resource.getFile()));
+    }
+
     File templateFile = new File(Play.tmpDir, path);
     if (!canBeReused(templateFile)) {
       loadTemplateFromClasspath(templateFile, resource);

--- a/javanet/src/play/server/javanet/PlayHandler.java
+++ b/javanet/src/play/server/javanet/PlayHandler.java
@@ -11,7 +11,6 @@ import static com.google.common.net.HttpHeaders.SET_COOKIE;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Collections.unmodifiableList;
 import static java.util.Objects.requireNonNullElse;
-import static org.apache.commons.lang3.StringUtils.defaultString;
 import static play.mvc.Http.Methods.GET;
 import static play.mvc.Http.Methods.HEAD;
 import static play.mvc.Http.StatusCode.BAD_REQUEST;
@@ -40,6 +39,7 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
@@ -531,7 +531,7 @@ public class PlayHandler implements HttpHandler {
   private void serve404(NotFound e, HttpExchange exchange, Http.Request request)
       throws IOException {
     logger.trace("serve404: begin");
-    String format = defaultString(request.format, "txt");
+    String format = Objects.toString(request.format, "txt");
     String contentType = MimeTypes.getContentType("404." + format, "text/plain");
     String errorHtml = serverHelper.generateNotFoundResponse(request, format, e);
     printResponse(exchange, NOT_FOUND, contentType, errorHtml);

--- a/replay-tests/helloworld/app/views/hello.html
+++ b/replay-tests/helloworld/app/views/hello.html
@@ -9,7 +9,7 @@
 <img id="img1" src="/img/banksy-kyiv-1.jpeg" width="300"/>
 <img id="img2" src="/img/banksy-kyiv-2.jpeg" width="300"/>
 <img id="img3" src="/img/banksy-kyiv-3.jpeg" width="300"/>
-<img id="img4" src="/img/benks-kyiv-4.jpeg" width="300"/>
+<img id="img4" src="/img/benksy-kyiv-4.jpeg" width="300"/>
 <img id="img5" src="/img/banksy-kyiv-5.jpeg" width="300"/>
 <img id="img6" src="/img/banksy-kyiv-6.jpeg" width="300"/>
 <img id="img7" src="/img/banksy-kyiv-7.jpeg" width="300"/>
@@ -37,6 +37,11 @@
 </div>
 <div style="width: 100%">
   <img id="img-from-play-local-file" src="/app/public/img/banksy-kyiv-7.jpeg" width="300"/>
+</div>
+
+<div>
+  <a id="repeat" href="@{controllers.HelloWorld.repeat(666)}">Repeat 666 times</a>
+  <a id="link-to-static-file" href="@{'/app/public/img/banksy-kyiv-7.jpeg'}">Link to image</a>
 </div>
 
 </body>

--- a/replay-tests/helloworld/build.gradle
+++ b/replay-tests/helloworld/build.gradle
@@ -5,6 +5,7 @@ dependencies {
   testImplementation(libs.pdfTest)
   testImplementation(libs.restAssured) {
     exclude group: 'org.apache.groovy'
+    exclude group: 'org.apache.commons', module: 'commons-lang3'
   }
   testImplementation(libs.jsonSchemaValidator)
   testImplementation(libs.jacksonDatabind) {

--- a/replay-tests/helloworld/test/ui/hello/LinksInHtmlSpec.java
+++ b/replay-tests/helloworld/test/ui/hello/LinksInHtmlSpec.java
@@ -1,0 +1,37 @@
+package ui.hello;
+
+import static com.codeborne.selenide.Condition.href;
+import static com.codeborne.selenide.Condition.text;
+import static com.codeborne.selenide.Selenide.$;
+import static com.codeborne.selenide.Selenide.open;
+import static com.codeborne.selenide.Selenide.webdriver;
+import static com.codeborne.selenide.WebDriverConditions.urlContaining;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class LinksInHtmlSpec extends BaseSpec {
+
+  @BeforeEach
+  final void openHelloPage() {
+    open("/");
+  }
+
+  @Test
+  public void linkToController() {
+    $("h1").shouldHave(text("Hello, world!"));
+
+    $("#repeat").shouldHave(text("Repeat 666 times"));
+    $("#repeat").click();
+
+    $("h1").shouldHave(text("Hello, world #666!"));
+  }
+
+  @Test
+  public void linkToStaticFile() {
+    $("#link-to-static-file")
+        .shouldHave(href("/public/img/banksy-kyiv-7.jpeg"))
+        .click();
+    webdriver().shouldHave(urlContaining("/public/img/banksy-kyiv-7.jpeg"));
+  }
+}

--- a/replay-tests/replay-tests.gradle
+++ b/replay-tests/replay-tests.gradle
@@ -57,8 +57,10 @@ tasks.register('uitest-netty3', Test) {
 tasks.register('uitest-netty4', Test) {
   include 'ui/**/*'
   exclude 'ui/hello/RenderStaticFilesSpec*'
+  exclude 'ui/hello/LinksInHtmlSpec*'
   exclude 'ui/hello/TagsInvolvesStaticFilesSpec*'
   // TODO: clarify why `replay-netty4` fails on static files
+  //       see https://github.com/replay-framework/replay/issues/157
   outputs.upToDateWhen { false }
   classpath = configurations.netty4TestClasspath + classpath
 }


### PR DESCRIPTION
When handling `@{'...'}`, method `Router.__reverseWithCheck()` is used.

@xabolcs 