### PR TITLE
fastergt: remove `__reverseWithCheck*` methods from `ExecutableTemplates`

### DIFF
--- a/fastergt/src/play/modules/gtengineplugin/gt_integration/GTJavaBase1xImpl.java
+++ b/fastergt/src/play/modules/gtengineplugin/gt_integration/GTJavaBase1xImpl.java
@@ -38,7 +38,7 @@ public abstract class GTJavaBase1xImpl extends GTJavaBase {
     return __reverseWithCheck(action, false);
   }
 
-  public static String __reverseWithCheck(String action, boolean absolute) {
+  private static String __reverseWithCheck(String action, boolean absolute) {
     return Router.reverseWithCheck(action, Play.file(action), absolute);
   }
 

--- a/fastergt/src/play/modules/gtengineplugin/gt_integration/GTPreCompiler1xImpl.java
+++ b/fastergt/src/play/modules/gtengineplugin/gt_integration/GTPreCompiler1xImpl.java
@@ -40,7 +40,7 @@ public class GTPreCompiler1xImpl extends GTPreCompiler {
     if (m.find()) {
       // This is an action/link to a static file.
       action = m.group(1); // without ''
-      code = " out.append(__reverseWithCheck(\"" + action + "\", " + absolute + "));\n";
+      code = " out.append(__reverseWithCheck_absolute_" + absolute + "(\"" + action + "\"));\n";
     } else {
       if (!action.endsWith(")")) {
         action = action + "()";

--- a/fastergt/src/play/templates/ExecutableTemplate.java
+++ b/fastergt/src/play/templates/ExecutableTemplate.java
@@ -130,18 +130,6 @@ public abstract class ExecutableTemplate extends Script {
     }
   }
 
-  public String __reverseWithCheck_absolute_true(String action) {
-    return __reverseWithCheck(action, true);
-  }
-
-  public String __reverseWithCheck_absolute_false(String action) {
-    return __reverseWithCheck(action, false);
-  }
-
-  private String __reverseWithCheck(String action, boolean absolute) {
-    return Router.reverseWithCheck(action, Play.file(action), absolute);
-  }
-
   public String __safe(Object val, String stringValue) {
     if (val instanceof BaseTemplate.RawData) {
       return ((BaseTemplate.RawData) val).data;


### PR DESCRIPTION
Remove `play.templates.ExecutableTemplates#__reverseWithCheck*()` methods as the only consumer
(`play.templates.GroovyTemplateCompiler#action()`) was gone with this `play.templates.ExecutableTemplates` class' debut in commit 185ca449d2d1cf656f3aed973625b4a0f0bea3f8.

**asolntsev**'s guess is that most of code in `ExecutableTemplates` is not used anymore.
It was used in "default" groovy templates in Play1 which were replaced by "faster groovy templates" in Replay.

But leave that cleanup for later!

While at it, improve their counterpart in fastergt plugin (`GTJavaBase1xImpl` and `GTPreCompiler1xImpl` classes and PR #524), to use the other two methods: `__reverseWithCheck_absolute_true()` and `__reverseWithCheck_absolute_false()`.

Ref: https://github.com/replay-framework/replay/pull/506/files#r1951693547
Fixes: 185ca449d2d1 ("remove old html templates implementation play.templates.TemplateCompiler")