### PR TITLE
use RedHat repository only for the needed dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,8 +30,16 @@ subprojects {
   repositories {
     mavenCentral()
     mavenLocal()
-    maven {
-      url "https://maven.repository.redhat.com/ga/"
+
+    exclusiveContent {
+      forRepository {
+        maven {
+          url 'https://maven.repository.redhat.com/ga/'
+        }
+      }
+      filter {
+        includeModule "commons-fileupload", "commons-fileupload"
+      }
     }
   }
 


### PR DESCRIPTION
otherwise, dependabot suggests to update multiple dependencies to strange versions like "3.10.6.Final-redhat-00001".

See for example https://github.com/replay-framework/replay/pull/562#issuecomment-2794621035