### PR TITLE
remove RedHat repository

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,17 +30,6 @@ subprojects {
   repositories {
     mavenCentral()
     mavenLocal()
-
-    exclusiveContent {
-      forRepository {
-        maven {
-          url 'https://maven.repository.redhat.com/ga/'
-        }
-      }
-      filter {
-        includeModule "commons-fileupload", "commons-fileupload"
-      }
-    }
   }
 
   sourceSets {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -54,7 +54,7 @@ guava = { group = "com.google.guava", name = "guava", version = "33.4.7-jre" }
 commonsBeanutils = { group = "commons-beanutils", name = "commons-beanutils", version = "1.10.1" }
 commonsCodec = { group = "commons-codec", name = "commons-codec", version = "1.18.0" }
 commonsEmail = { group = "org.apache.commons", name = "commons-email", version = "1.6.0" }
-commonsFileUpload = { group = "commons-fileupload", name = "commons-fileupload", version = "1.5.0.redhat-00001" }
+commonsFileUpload = { group = "commons-fileupload", name = "commons-fileupload", version = "1.5" }
 commonsIo = { group = "commons-io", name = "commons-io", version = "2.18.0" }
 commonsLang3 = { group = "org.apache.commons", name = "commons-lang3", version.ref = "commonsLangVersion" }
 commonsText = { group = "org.apache.commons", name = "commons-text", version.ref = "commonsTextVersion" }


### PR DESCRIPTION
this reverts commit c0c618fcd and PR #563

We realized that commons-fileupload 1.5 version is not affected by CVE-2023-24998, see https://github.com/replay-framework/replay/pull/562#issuecomment-2794871714